### PR TITLE
Remove unnecessary navigation code from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-nav: exclude
----
-
 # Orange Robotics Blog
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/3b80a397-e5fa-41ff-8913-3b28d0dd628a/deploy-status)](https://app.netlify.com/sites/eccentricorange/deploys)


### PR DESCRIPTION
This pull request removes unnecessary navigation code from the README.md file. Now that README.md is separate from docs/ it shouldn't automatically be included